### PR TITLE
fix: Allowing new version of colorama

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,1 +1,1 @@
-colorama==0.4.1
+colorama>=0.4.1


### PR DESCRIPTION
You have blocked the version of `colorama` in your dependencies and it cause issues when trying to make `python-semantic-release` and `rich` working together with poetry:

```
[SolverProblemError]
    Because no versions of python-semantic-release match >5.0.2,<6.0.0
 and python-semantic-release (5.0.2) depends on ndebug (>=0.1,<1.0), python-semantic-release (>=5.0.2,<6.0.0) requires ndebug (>=0.1,<1.0).
(1) So, because no versions of ndebug match >0.1,<1.0
 and ndebug (0.1.0) depends on colorama (0.4.1), python-semantic-release (>=5.0.2,<6.0.0) requires colorama (0.4.1).

    Because no versions of rich match >0.7.0,<0.7.1 || >0.7.1,<0.7.2 || >0.7.2,<0.8.0
 and rich (0.7.0) depends on colorama (>=0.4.3,<0.5.0), rich (>=0.7.0,<0.7.1 || >0.7.1,<0.7.2 || >0.7.2,<0.8.0) requires colorama (>=0.4.3,<0.5.0).
    And because rich (0.7.1) depends on colorama (>=0.4.3,<0.5.0)
 and rich (0.7.2) depends on colorama (>=0.4.3,<0.5.0), rich (>=0.7.0,<0.8.0) requires colorama (>=0.4.3,<0.5.0).
    And because python-semantic-release (>=5.0.2,<6.0.0) requires colorama (0.4.1) (1), python-semantic-release (>=5.0.2,<6.0.0) is incompatible with rich (>=0.7.0,<0.8.0)
    So, because gojira depends on both rich (^0.7.0) and python-semantic-release (^5.0.2), version solving failed.
```